### PR TITLE
readme.md explains the .app files are in sub-folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/jbtule/cdto
 
 Download [Latest cdto.zip](https://github.com/jbtule/cdto/releases/latest)
 
-To install "cd to.app" copy it to your Applications folder, and then from the applications folder drag it into the Finder toolbar (10.9 Mavericks requires ⌘ + ⌥) 
+To install "cd to.app" copy it from the appropriate sub-folder (iterm//x11_xterm/unsigned per your choice) to your Applications folder, and then from the applications folder drag it into the Finder toolbar (10.9 Mavericks requires ⌘ + ⌥) 
 
 To use, just click on the new button and instanly opens a new terminal window.
 


### PR DESCRIPTION
It took me a few seconds and an extra googling to realize the .app file is in one of the sub-folders.
I think the readme more clearly explains this now
