### PR TITLE
get application path from bundle identifier

### DIFF
--- a/plugins/iterm/CD2ITerm.m
+++ b/plugins/iterm/CD2ITerm.m
@@ -11,9 +11,13 @@
 @implementation CD2ITerm
 -(BOOL)openTermWindowForPath:(NSString*)aPath{
 	@try{
-        
-        [[NSWorkspace sharedWorkspace] openFile:[aPath stringByExpandingTildeInPath] withApplication:@"iTerm.app"];
+        NSString *iterm2AbsolutePath;
+        iterm2AbsolutePath = [[NSWorkspace sharedWorkspace] absolutePathForAppBundleWithIdentifier:@"com.googlecode.iterm2"];
 
+        if (iterm2AbsolutePath)
+            [[NSWorkspace sharedWorkspace] openFile:[aPath stringByExpandingTildeInPath]
+                                    withApplication:iterm2AbsolutePath
+                                      andDeactivate:YES];
 
 	}@catch(id test){
 		return NO;


### PR DESCRIPTION
Avoid using hardcoded application bundle, the program installed with MacPorts has "iTerm2.app" name.
This approach is more general and will find whatever instance of the app comes first in Finder.
