### PR TITLE
use owner lines from xterm plugin file

### DIFF
--- a/plugins/iterm/CD2ITerm.m
+++ b/plugins/iterm/CD2ITerm.m
@@ -3,7 +3,7 @@
 //  iterm
 //
 //  Created by James Tuley on 2/18/07.
-//  Copyright 2007 __MyCompanyName__. All rights reserved.
+//  Copyright 2007 Jay Tuley. All rights reserved.
 //
 
 #import "CD2ITerm.h"

--- a/plugins/terminal/CD2Terminal.m
+++ b/plugins/terminal/CD2Terminal.m
@@ -3,7 +3,7 @@
 //  terminal
 //
 //  Created by James Tuley on 2/18/07.
-//  Copyright 2007 __MyCompanyName__. All rights reserved.
+//  Copyright 2007 Jay Tuley. All rights reserved.
 //
 
 #import "CD2Terminal.h"


### PR DESCRIPTION
Use full name instead of Xcode's generic template in plugins' implementation files.
