### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##cd to...
+## cd to...
 <img src="https://raw.github.com/jbtule/cdto/master/graphics/lion.png" height="128px" width="128px" />
 
 Finder Toolbar app to open the current directory in the Terminal (or iTerm, X11)
@@ -9,7 +9,7 @@ Finder Toolbar app to open the current directory in the Terminal (or iTerm, X11)
 By Jay Tuley
 https://github.com/jbtule/cdto
 
-###Usage:
+### Usage:
 
 Download [Latest cdto.zip](https://github.com/jbtule/cdto/releases/latest)
 
@@ -20,7 +20,7 @@ To use, just click on the new button and instanly opens a new terminal window.
 For old versions to use with iTerm or X11/xterm, using the finder contextual menu "show package contents"  and exchange the plugins in the Plugin/Plugin Disabled folders respectively.  Next time you run  "cd to ..." it should open with the correct application.
 
 
-###Changes:
+### Changes:
 Version 2.6
  * Fixed bug where get info window interferes
  * works on selected folder again


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
